### PR TITLE
 Implement half arsed locale handling 

### DIFF
--- a/app/Sheets.php
+++ b/app/Sheets.php
@@ -133,6 +133,10 @@ class Sheets
      */
     public function appendRow(string $spreadsheetId, string $sheetId, array $row)
     {
+        // We'd much rather use RAW, but then dates aren't parsed. So until
+        // someone rewrites this to be able to switch between RAW and
+        // USER_ENTERED depending on content, we'll use USER_ENTERED and
+        // translate the decimal separator for numbers.
         $options = ['valueInputOption' => 'USER_ENTERED'];
         $values = new Google_Service_Sheets_ValueRange(['values' => [$row]]);
         $result = $this->sheets->spreadsheets_values->append(

--- a/tests/Feature/UpdateSheetsTest.php
+++ b/tests/Feature/UpdateSheetsTest.php
@@ -33,7 +33,7 @@ class UpdateSheetsTest extends TestCase
             'id' => '500',
         ];
 
-        $mapping = [
+        $sheets = [
             [
                 'sheet' => 'the-sheet',
                 'tab' => 'the-tab',
@@ -42,7 +42,7 @@ class UpdateSheetsTest extends TestCase
 
         Log::shouldReceive("error")->with('Error "The "id" field must be mapped." while mapping {"sheet":"the-sheet","tab":"the-tab"}')->once();
 
-        putenv('SHEETS=' . YAML::dump($mapping));
+        putenv('SHEETS=' . YAML::dump($sheets));
 
         $ac = $this->prophesize(ActiveCampaign::class);
         $ac->get(42)->willReturn($deal);
@@ -63,14 +63,14 @@ class UpdateSheetsTest extends TestCase
             'id' => '500',
         ];
 
-        $mapping = [
+        $sheets = [
             [
                 'sheet' => 'the-sheet',
                 'tab' => 'the-tab',
             ],
         ];
 
-        putenv('SHEETS=' . YAML::dump($mapping));
+        putenv('SHEETS=' . YAML::dump($sheets));
 
         $ac = $this->prophesize(ActiveCampaign::class);
         $ac->get(42)->willReturn($deal);
@@ -94,14 +94,14 @@ class UpdateSheetsTest extends TestCase
             'cdate' => '2019-02-13T03:12:08-06:00',
         ];
 
-        $mapping = [
+        $sheets = [
             [
                 'sheet' => 'the-sheet',
                 'tab' => 'the-tab',
             ],
         ];
 
-        putenv('SHEETS=' . YAML::dump($mapping));
+        putenv('SHEETS=' . YAML::dump($sheets));
 
         $ac = $this->prophesize(ActiveCampaign::class);
         $ac->get(42)->willReturn($deal);
@@ -131,14 +131,14 @@ class UpdateSheetsTest extends TestCase
             ['two', 500],
             ['three', 501],
         ];
-        $mapping = [
+        $sheets = [
             [
                 'sheet' => 'the-sheet',
                 'tab' => 'the-tab',
             ],
         ];
 
-        putenv('SHEETS=' . YAML::dump($mapping));
+        putenv('SHEETS=' . YAML::dump($sheets));
 
         $ac = $this->prophesize(ActiveCampaign::class);
         $ac->get(42)->willReturn($deal);
@@ -155,7 +155,7 @@ class UpdateSheetsTest extends TestCase
 
     public function testCatchingErrorsInAC()
     {
-        $mapping = [
+        $sheets = [
             [
                 'sheet' => 'the-sheet',
                 'tab' => 'the-tab',
@@ -167,7 +167,7 @@ class UpdateSheetsTest extends TestCase
 
         Log::shouldReceive("error")->with('Error fetching deal 42: bad stuff')->once();
 
-        putenv('SHEETS=' . YAML::dump($mapping));
+        putenv('SHEETS=' . YAML::dump($sheets));
 
         $ac = $this->prophesize(ActiveCampaign::class);
         $ac->get(42)->willThrow(new RuntimeException('bad stuff'));
@@ -190,7 +190,7 @@ class UpdateSheetsTest extends TestCase
             'cdate' => '2019-02-13T03:12:08-06:00',
         ];
 
-        $mapping = [
+        $sheets = [
             [
                 'sheet' => 'the-sheet',
                 'tab' => 'the-tab',
@@ -198,7 +198,7 @@ class UpdateSheetsTest extends TestCase
             ],
         ];
 
-        putenv('SHEETS=' . YAML::dump($mapping));
+        putenv('SHEETS=' . YAML::dump($sheets));
 
         $ac = $this->prophesize(ActiveCampaign::class);
         $ac->get(42)->willReturn($deal);

--- a/tests/Unit/UpdateSheetsTest.php
+++ b/tests/Unit/UpdateSheetsTest.php
@@ -76,8 +76,8 @@ class UpdateSheetsTest extends TestCase
 
         $expected = [
             'untranslated' => '2019-02-13T03:12:08-06:00',
-            'cdate' => '2019-02-13 09.12.08',
-            'mdate' => '2019-02-13 09.12.08',
+            'cdate' => '2019-02-13 09:12:08',
+            'mdate' => '2019-02-13 09:12:08',
         ];
 
         $this->assertEquals($expected, $updater->translateFields($deal));
@@ -133,5 +133,35 @@ class UpdateSheetsTest extends TestCase
             'value' => '8',
         ];
         $this->assertEquals($expected, $updater->translateFields($deal));
+    }
+
+    public function testLanguageTranslation()
+    {
+        // Suppress log output.
+        Log::spy();
+
+        $ac = $this->prophesize(ActiveCampaign::class);
+        $sheets = $this->prophesize(Sheets::class);
+
+        $updater = new UpdateSheets($ac->reveal(), $sheets->reveal());
+
+        $deal = [
+            'cdate' => '2019-02-13T03:12:08-06:00',
+            'some-value' => '3.14',
+            'some-array' => ['3.14'],
+        ];
+        $expected = [
+            'cdate' => '2019-02-13 09:12:08',
+            'some-value' => '3.14',
+            'some-array' => ['3.14'],
+        ];
+        $this->assertEquals($expected, $updater->translateFields($deal));
+
+        $expected = [
+            'cdate' => '2019-02-13 09.12.08',
+            'some-value' => '3,14',
+            'some-array' => ['3.14'],
+        ];
+        $this->assertEquals($expected, $updater->translateFields($deal, true));
     }
 }


### PR DESCRIPTION
One can either use `RAW` or `USER_ENTERED` when inserting values, however the first doesn't understand dates (they're inserted as strings), and the latter expect `,` as a decimal separator for numbers.

So, stick with `USER_ENTERED` and translate the decimal separator for numbers.

Closes #1 