### PR TITLE
Properly authenticate with GHCR

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,10 +31,8 @@ jobs:
       uses: docker/login-action@v1.12.0
       with:
         registry: ghcr.io
-        username: ${{ github.repository_owner }}
-        # Currently ghcr.io only supports a personal access token, so
-        # this is one from reload-deploy.
-        password: ${{ secrets.GHCR_TOKEN }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
     - name: Build and push Docker images
       uses: docker/build-push-action@v2.7.0
       with:


### PR DESCRIPTION
GHCR doesn't require a PAT anymore, so use GITHUB_TOKEN.
